### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/0-PROJECTS/01-01-25-CZ.md
+++ b/0-PROJECTS/01-01-25-CZ.md
@@ -590,7 +590,7 @@ pydub==0.25.1
 librosa==0.10.1
 soundfile==0.12.1
 phonemizer==3.2.1
-pyautogen==0.2.0
+ag2==0.2.0
 scikit-learn==1.3.2
 matplotlib==3.8.2
 seaborn==0.13.0

--- a/100-ag2/102-ag2-basics-1.ipynb
+++ b/100-ag2/102-ag2-basics-1.ipynb
@@ -77,12 +77,12 @@
    "id": "dd1ce09e-02c6-484b-ad6c-74e3de0603a0",
    "metadata": {},
    "source": [
-    "If you have been using autogen or pyautogen, all you need to do is upgrade it using:\n",
+    "If you have been using autogen or ag2, all you need to do is upgrade it using:\n",
     "```\n",
     "pip install -U autogen[openai]\n",
-    "pip install -U pyautogen[openai]\n",
+    "pip install -U ag2[openai]\n",
     "```\n",
-    "as **pyautogen**, **autogen**, and **ag2** are aliases for the same PyPI package."
+    "as **ag2**, **autogen**, and **ag2** are aliases for the same PyPI package."
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyterlab
-pyautogen
+ag2
 ag2[openai]
 crewai
 crewai-tools


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
